### PR TITLE
Added /etc/rc.shutdown, called in runlevel 3

### DIFF
--- a/3
+++ b/3
@@ -16,6 +16,8 @@ msg "Waiting for services to stop...\n"
 sv force-stop /var/service/*
 sv exit /var/service/*
 
+[ -x /etc/rc.shutdown ] && /etc/rc.shutdown
+
 msg "Saving random seed...\n"
 dd if=/dev/urandom of=/var/lib/random-seed count=1 bs=512 >/dev/null 2>&1
 

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ install:
 	install -m644 functions $(DESTDIR)/etc/runit
 	install -m644 rc.conf ${DESTDIR}/etc
 	install -m755 rc.local ${DESTDIR}/etc
+	install -m755 rc.shutdown ${DESTDIR}/etc
 	install -d ${DESTDIR}/${PREFIX}/lib/dracut/dracut.conf.d
 	install -m644 dracut/*.conf ${DESTDIR}/${PREFIX}/lib/dracut/dracut.conf.d
 	ln -sf /run/runit/reboot ${DESTDIR}/etc/runit/

--- a/rc.shutdown
+++ b/rc.shutdown
@@ -1,0 +1,4 @@
+# Default rc.shutdown for void; add your custom commands here.
+#
+# This is run by runit in stage 3 after the services are stopped
+# (see /etc/runit/3).


### PR DESCRIPTION
The runit-void package probably needs to be adapted as well. I can do that when this is through.