### PR TITLE
Restrict access to /var/log/dmesg.log

### DIFF
--- a/1
+++ b/1
@@ -16,6 +16,11 @@ for f in /etc/runit/core-services/*.sh; do
 done
 
 dmesg >/var/log/dmesg.log
+if [ $(sysctl -n kernel.dmesg_restrict 2>/dev/null) -eq 1 ]; then
+	chmod 0600 /var/log/dmesg.log
+else
+	chmod 0644 /var/log/dmesg.log
+fi
 
 mkdir -p /run/runit
 install -m100 /dev/null /run/runit/stopit


### PR DESCRIPTION
If `kernel.dmesg_restrict` is set than only root is allowed to access `dmesg(1)`. However, by default `/var/log/dmesg.log` can also be read by non-root users even if `kernel.dmesg_restrict` is set. This pull requests attempts to change that.