### PR TITLE
Use read to retrieve the hostname

### DIFF
--- a/core-services/05-misc.sh
+++ b/core-services/05-misc.sh
@@ -10,7 +10,7 @@ ip link set up dev lo
 if [ -n "$HOSTNAME" ]; then
     echo "$HOSTNAME" > /proc/sys/kernel/hostname
 elif [ -r /etc/hostname ]; then
-    HOSTNAME=$(cat /etc/hostname)
+    read -r HOSTNAME < /etc/hostname
     echo "$HOSTNAME" > /proc/sys/kernel/hostname
 fi
 msg "Setting up hostname to '${HOSTNAME}'...\n"


### PR DESCRIPTION
This is just a small improvement, but generally speaking it is a better idea to use `read(1)` instead of `cat(1)` when assigning the content of a file to a variable.