### PR TITLE
Add an additional variable to rc.conf for TTYs

### DIFF
--- a/core-services/02-console-setup.sh
+++ b/core-services/02-console-setup.sh
@@ -2,10 +2,15 @@
 
 [ -n "$VIRTUALIZATION" ] && return 0
 
+TTYS=${TTYS:-12}
 if [ -n "$FONT" ]; then
     msg "Setting up TTYs font to '${FONT}'..."
-    for i in /dev/tty[0-6]; do
-        setfont ${FONT_MAP:+-m $FONT_MAP} ${FONT_UNIMAP:+-u $FONT_UNIMAP} $FONT -C $i
+
+    _index=0
+    while [ ${_index} -le $TTYS ]; do
+        setfont ${FONT_MAP:+-m $FONT_MAP} ${FONT_UNIMAP:+-u $FONT_UNIMAP} \
+                $FONT -C "/dev/tty${_index}"
+        _index=$((_index + 1))
     done
 fi
 

--- a/rc.conf
+++ b/rc.conf
@@ -25,6 +25,9 @@
 # Font unimap to load, see setfont(8).
 #FONT_UNIMAP=
 
+# Amount of ttys which should be setup.
+#TTYS=
+
 # Kernel modules to load, delimited by blanks.
 #
 # NOTE: it's preferred to declare the modules in /etc/modules-load.d instead:


### PR DESCRIPTION
In general it kind of sucks that ttys are setup in `core-services/` because if you want to setup more or less than 6 ttys you need to manually edit that file.