### PR TITLE
2: Handle single the same way as any other runlevel

### DIFF
--- a/2
+++ b/2
@@ -5,9 +5,6 @@ PATH=/usr/bin:/usr/sbin
 
 runlevel=default
 for arg in $(cat /proc/cmdline); do
-    case $arg in
-        single) echo "Initializing single user mode..."; runlevel=single;;
-    esac
     if [ -d /etc/runit/runsvdir/"$arg" ]; then
         echo "Runlevel detected: '$arg' (via kernel cmdline)"
         runlevel="$arg"


### PR DESCRIPTION
I don't see why the single runlevel needs to be handled in a 'special way'. The additional output "Initializing single user mode..." seems to be kind of redundant.