### PR TITLE
Remove ability to declare kernel modules in rc.conf

### DIFF
--- a/core-services/07-kmods.sh
+++ b/core-services/07-kmods.sh
@@ -3,5 +3,5 @@
 [ -n "$VIRTUALIZATION" ] && return 0
 
 msg "Loading kernel modules..."
-modules-load -v ${MODULES} | tr '\n' ' ' | sed 's:insmod [^ ]*/::g; s:\.ko\(\.gz\)\? ::g'
+modules-load -v | tr '\n' ' ' | sed 's:insmod [^ ]*/::g; s:\.ko\(\.gz\)\? ::g'
 echo

--- a/rc.conf
+++ b/rc.conf
@@ -27,10 +27,3 @@
 
 # Amount of ttys which should be setup.
 #TTYS=
-
-# Kernel modules to load, delimited by blanks.
-#
-# NOTE: it's preferred to declare the modules in /etc/modules-load.d instead:
-# 	- echo kmod > /etc/modules-load.d/kmod.conf
-#
-#MODULES=""


### PR DESCRIPTION
The preferred way is to declare them in `/etc/modules-load.d` so why offer an additional way? This isn't perl.