### PR TITLE
Refactor services/*

### DIFF
--- a/services/agetty-console/conf
+++ b/services/agetty-console/conf
@@ -1,0 +1,2 @@
+baud_rate=38400
+term_name=linux

--- a/services/agetty-console/conf
+++ b/services/agetty-console/conf
@@ -1,2 +1,2 @@
-baud_rate=38400
-term_name=linux
+BAUD_RATE=38400
+TERM_NAME=linux

--- a/services/agetty-console/finish
+++ b/services/agetty-console/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-console/run
+++ b/services/agetty-console/run
@@ -1,7 +1,1 @@
-#!/bin/sh
-if [ -x /sbin/getty ]; then
-	GETTY=getty
-elif [ -x /sbin/agetty ]; then
-	GETTY=agetty
-fi
-exec $GETTY console 38400 linux
+../agetty-generic/run

--- a/services/agetty-generic/run
+++ b/services/agetty-generic/run
@@ -12,4 +12,4 @@ elif [ -x /sbin/agetty ]; then
 fi
 
 exec setsid ${GETTY}${GETTY_ARGS:+ $GETTY_ARGS} \
-	"${tty}" "${baud_rate}" "${term_name}"
+	"${tty}" "${BAUD_RATE}" "${TERM_NAME}"

--- a/services/agetty-generic/run
+++ b/services/agetty-generic/run
@@ -1,4 +1,7 @@
 #!/bin/sh
+
+[ -r conf ] && . conf
+
 tty=${PWD##*-}
 if [ -x /sbin/getty ]; then
 	# busybox
@@ -7,4 +10,6 @@ elif [ -x /sbin/agetty ]; then
 	# util-linux
 	GETTY=agetty
 fi
-exec setsid $GETTY $tty 38400 linux
+
+exec setsid ${GETTY}${GETTY_ARGS:+ $GETTY_ARGS} \
+	"${tty}" "${baud_rate}" "${term_name}"

--- a/services/agetty-serial/conf
+++ b/services/agetty-serial/conf
@@ -1,5 +1,5 @@
 GETTY_ARGS="-L"
-if [ -x /sbin/getty ]; then
+if [ -x /sbin/agetty ]; then
 	# util-linux specific settings
 	GETTY_ARGS="${GETTY_ARGS} -8"
 fi

--- a/services/agetty-serial/conf
+++ b/services/agetty-serial/conf
@@ -3,5 +3,5 @@ if [ -x /sbin/getty ]; then
 	GETTY_ARGS="-8 -L"
 fi
 
-baud_rate=115200
-term_name=vt100
+BAUD_RATE=115200
+TERM_NAME=vt100

--- a/services/agetty-serial/conf
+++ b/services/agetty-serial/conf
@@ -1,6 +1,7 @@
+GETTY_ARGS="-L"
 if [ -x /sbin/getty ]; then
 	# util-linux specific settings
-	GETTY_ARGS="-8 -L"
+	GETTY_ARGS="${GETTY_ARGS} -8"
 fi
 
 BAUD_RATE=115200

--- a/services/agetty-serial/conf
+++ b/services/agetty-serial/conf
@@ -1,0 +1,7 @@
+if [ -x /sbin/getty ]; then
+	# util-linux specific settings
+	GETTY_ARGS="-8 -L"
+fi
+
+baud_rate=115200
+term_name=vt100

--- a/services/agetty-serial/finish
+++ b/services/agetty-serial/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-serial/run
+++ b/services/agetty-serial/run
@@ -1,3 +1,1 @@
-#!/bin/sh
-tty=${PWD##*-}
-exec setsid agetty -8 -L 115200 --noclear $tty vt100
+../agetty-generic/run

--- a/services/agetty-tty1/conf
+++ b/services/agetty-tty1/conf
@@ -3,5 +3,5 @@ if [ -x /sbin/getty ]; then
 	GETTY_ARGS="--no-clear"
 fi
 
-baud_rate=38400
-term_name=linux
+BAUD_RATE=38400
+TERM_NAME=linux

--- a/services/agetty-tty1/conf
+++ b/services/agetty-tty1/conf
@@ -1,0 +1,7 @@
+if [ -x /sbin/getty ]; then
+	# util-linux specific settings
+	GETTY_ARGS="--no-clear"
+fi
+
+baud_rate=38400
+term_name=linux

--- a/services/agetty-tty1/conf
+++ b/services/agetty-tty1/conf
@@ -1,4 +1,4 @@
-if [ -x /sbin/getty ]; then
+if [ -x /sbin/agetty ]; then
 	# util-linux specific settings
 	GETTY_ARGS="--no-clear"
 fi

--- a/services/agetty-tty1/finish
+++ b/services/agetty-tty1/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-tty1/run
+++ b/services/agetty-tty1/run
@@ -1,11 +1,1 @@
-#!/bin/sh
-tty=${PWD##*-}
-if [ -x /sbin/getty ]; then
-	# busybox
-	GETTY=getty
-elif [ -x /sbin/agetty ]; then
-	# util-linux
-	GETTY=agetty
-	GETTY_ARGS="--noclear"
-fi
-exec setsid $GETTY $GETTY_ARGS $tty 38400 linux
+../agetty-generic/run

--- a/services/agetty-tty2/conf
+++ b/services/agetty-tty2/conf
@@ -1,0 +1,1 @@
+../agetty-tty1/conf

--- a/services/agetty-tty2/finish
+++ b/services/agetty-tty2/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-tty2/run
+++ b/services/agetty-tty2/run
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/run
+../agetty-generic/run

--- a/services/agetty-tty3/conf
+++ b/services/agetty-tty3/conf
@@ -1,0 +1,1 @@
+../agetty-tty1/conf

--- a/services/agetty-tty3/finish
+++ b/services/agetty-tty3/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-tty3/run
+++ b/services/agetty-tty3/run
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/run
+../agetty-generic/run

--- a/services/agetty-tty4/conf
+++ b/services/agetty-tty4/conf
@@ -1,0 +1,1 @@
+../agetty-tty1/conf

--- a/services/agetty-tty4/finish
+++ b/services/agetty-tty4/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-tty4/run
+++ b/services/agetty-tty4/run
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/run
+../agetty-generic/run

--- a/services/agetty-tty5/conf
+++ b/services/agetty-tty5/conf
@@ -1,0 +1,1 @@
+../agetty-tty1/conf

--- a/services/agetty-tty5/finish
+++ b/services/agetty-tty5/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-tty5/run
+++ b/services/agetty-tty5/run
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/run
+../agetty-generic/run

--- a/services/agetty-tty6/conf
+++ b/services/agetty-tty6/conf
@@ -1,0 +1,1 @@
+../agetty-tty1/conf

--- a/services/agetty-tty6/finish
+++ b/services/agetty-tty6/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-tty6/run
+++ b/services/agetty-tty6/run
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/run
+../agetty-generic/run

--- a/services/agetty-ttyAMA0/conf
+++ b/services/agetty-ttyAMA0/conf
@@ -1,0 +1,1 @@
+../agetty-serial/conf

--- a/services/agetty-ttyAMA0/finish
+++ b/services/agetty-ttyAMA0/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-ttyAMA0/run
+++ b/services/agetty-ttyAMA0/run
@@ -1,1 +1,1 @@
-/etc/sv/agetty-serial/run
+../agetty-serial/run

--- a/services/agetty-ttyS0/conf
+++ b/services/agetty-ttyS0/conf
@@ -1,0 +1,1 @@
+../agetty-serial/conf

--- a/services/agetty-ttyS0/finish
+++ b/services/agetty-ttyS0/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-ttyS0/run
+++ b/services/agetty-ttyS0/run
@@ -1,1 +1,1 @@
-/etc/sv/agetty-serial/run
+../agetty-serial/run

--- a/services/agetty-ttyUSB0/conf
+++ b/services/agetty-ttyUSB0/conf
@@ -1,0 +1,1 @@
+../agetty-serial/conf

--- a/services/agetty-ttyUSB0/finish
+++ b/services/agetty-ttyUSB0/finish
@@ -1,1 +1,1 @@
-/etc/sv/agetty-generic/finish
+../agetty-generic/finish

--- a/services/agetty-ttyUSB0/run
+++ b/services/agetty-ttyUSB0/run
@@ -1,1 +1,1 @@
-/etc/sv/agetty-serial/run
+../agetty-serial/run


### PR DESCRIPTION
This is basically an improved version of #27 however, this time the `--no-clear` flag remains enabled by default for agetty (even though I still consider this a bad idea). Furthermore, relative symlinks are used almost everywhere and `conf` files are provided by default. In addition to that `agetty-console` is now also compatible with getty.

Basically there is now **one** generic run file located in `agetty-generic/run` and three configuration files:

1. agetty-serial/conf
2. agetty-tty1/conf
3. agetty-console/conf

Every other services uses the run file provided by agetty-generic and one of the conf files listed above using symlinks.