### PR TITLE
agetty-generic: fix strange space substitution

### DIFF
--- a/services/agetty-generic/run
+++ b/services/agetty-generic/run
@@ -12,5 +12,5 @@ elif [ -x /sbin/agetty -o -x /bin/agetty ]; then
 	GETTY=agetty
 fi
 
-exec setsid ${GETTY}${GETTY_ARGS:+ $GETTY_ARGS} \
+exec setsid ${GETTY} ${GETTY_ARGS} \
 	"${tty}" "${BAUD_RATE}" "${TERM_NAME}"


### PR DESCRIPTION
I don't know why it was like this before.
Someone set zsh as sh and it tried to start "agetty--no-clear" for tty1.