### PR TITLE
Don't output newline to /proc file when setting hostname.

### DIFF
--- a/core-services/05-misc.sh
+++ b/core-services/05-misc.sh
@@ -10,7 +10,7 @@ ip link set up dev lo
 [ -r /etc/hostname ] && read -r HOSTNAME < /etc/hostname
 if [ -n "$HOSTNAME" ]; then
     msg "Setting up hostname to '${HOSTNAME}'..."
-    echo "$HOSTNAME" > /proc/sys/kernel/hostname
+    printf "%s" "$HOSTNAME" > /proc/sys/kernel/hostname
 else
     msg_warn "Didn't setup a hostname!"
 fi


### PR DESCRIPTION
This breaks in certain combinations of echo command and standard
library, notably musl and bash builtin echo,
or coreutils echo + musl.