### PR TITLE
Allow skipping LVM activation before LUKS.

### DIFF
--- a/core-services/03-filesystems.sh
+++ b/core-services/03-filesystems.sh
@@ -15,9 +15,13 @@ if [ -x /bin/btrfs ]; then
     btrfs device scan || emergency_shell
 fi
 
-if [ -x /sbin/vgchange -o -x /bin/vgchange ]; then
-    msg "Activating LVM devices..."
-    vgchange --sysinit -a y || emergency_shell
+if [ "$LVMONLUKS" = "1" ]; then
+    msg "You set LVMONLUKS, skipping LVM activation before activation of encrypted devices."
+else
+    if [ -x /sbin/vgchange -o -x /bin/vgchange ]; then
+        msg "Activating LVM devices..."
+        vgchange --sysinit -a y || emergency_shell
+    fi
 fi
 
 if [ -e /etc/crypttab ]; then


### PR DESCRIPTION
This is only useful if you have secondary LUKS partitions that are unlocked via /etc/crypttab and a keyfile on your root partition and that contain secondary LVM PVs.
If not used, any LV which is extended to use any secondary PV would cause vgchange to fail due to partial availability and drop into the emergency_shell.

WARNING: It is your responsability to ensure that your root partition stays accessible.
         In particular, make sure that your root parition, if on LVM, is never extended onto a secondary PV as this may cause your system to become deadlocked!
         Make sure that in an emergency situation you could unlock all secondary LUKS paritions without access to your root parition!

If you understand the above warnings, you can enable this by setting LVMONLUKS=1, e.g. by adding it to GRUB_CMDLINE_LINUX_DEFAULT in /etc/default/grub and running update-grub.