### PR TITLE
Improve support of the zfs config file

### DIFF
--- a/core-services/03-filesystems.sh
+++ b/core-services/03-filesystems.sh
@@ -30,15 +30,13 @@ if [ -e /etc/crypttab ]; then
     fi
 fi
 
-if [ -e /etc/zfs/zpool.cache -a -x /usr/bin/zfs ]; then
+if [ -e "$(zfs_cachefile)" -a -x /usr/bin/zfs ]; then
     msg "Activating ZFS devices..."
     zpool import -c /etc/zfs/zpool.cache -N -a
 
-    msg "Mounting ZFS file systems..."
-    zfs mount -a
+    zfs_mount
 
-    msg "Sharing ZFS file systems..."
-    zfs share -a
+    zfs_share
 
     # NOTE(dh): ZFS has ZVOLs, block devices on top of storage pools.
     # In theory, it would be possible to use these as devices in

--- a/functions
+++ b/functions
@@ -35,6 +35,40 @@ detect_virt() {
    fi
 }
 
+zfs_cachefile() {
+   local cache=/etc/zfs/zpool.cache
+   if [ -f /etc/default/zfs ]; then
+      . /etc/default/zfs
+      : ${ZPOOL_CACHE:=/etc/zfs/zpool.cache}
+      cache=$ZPOOL_CACHE
+   fi
+   printf "$cache"
+}
+
+zfs_mount() {
+   if [ -f /etc/default/zfs ]; then                                             
+      . /etc/default/zfs                                                        
+      case $ZFS_MOUNT in
+         yes|on|true|1)
+	     msg "Mounting ZFS file systems..."
+	     zfs mount -a
+             ;;
+      esac
+   fi
+}
+
+zfs_share() {
+   if [ -f /etc/default/zfs ]; then                                             
+      . /etc/default/zfs                                                        
+      case $ZFS_SHARE in
+         yes|on|true|1)
+	     msg "Sharing ZFS file systems..."
+	     zfs share -a
+             ;;
+      esac
+   fi
+}
+
 deactivate_vgs() {
    _group=${1:-All}
    if [ -x /sbin/vgchange -o -x /bin/vgchange ]; then


### PR DESCRIPTION
Before this commit, the file at /etc/default/zfs was ignored.
If ZFS_MOUNT was not equal to one of the four true values
(yes, on, true, or 1) the mount command was still executed.
Same with share.
The code also precluded the possibility of not using the default
cache file.