### PR TITLE
sulogin OPTS

### DIFF
--- a/services/sulogin/run
+++ b/services/sulogin/run
@@ -1,4 +1,5 @@
 #!/bin/sh
+[ -r conf ] && . ./conf
 read -r tty < /sys/class/tty/console/active
 tty=/dev/${tty##* }
-exec setsid sulogin -p < $tty >$tty 2>&1
+exec setsid sulogin ${OPTS:=-p} < $tty >$tty 2>&1


### PR DESCRIPTION
https://forum.voidlinux.eu/t/rescue-mode-sulogin/561/12

Allows rescue mode to be configured to work with a locked root account and sudo.
Thanks to Duncaen.