### PR TITLE
Make crypt.awk work with other awk(1) variants.

### DIFF
--- a/crypt.awk
+++ b/crypt.awk
@@ -3,7 +3,7 @@ NF>4 { print "a valid crypttab has max 4 cols not " NF >"/dev/stderr"; next }
 {
     # decode the src variants
     split($2, o_src, "=")
-    if (o_src[1] == "UUID") "blkid -t " $2 " -l -o device" | getline src;
+    if (o_src[1] == "UUID") ("blkid -l -o device -t " $2) | getline src;
     else src=o_src[1];
 
     # no password or none is given, ask fo it

--- a/crypt.awk
+++ b/crypt.awk
@@ -3,7 +3,7 @@ NF>4 { print "a valid crypttab has max 4 cols not " NF >"/dev/stderr"; next }
 {
     # decode the src variants
     split($2, o_src, "=")
-    if (o_src[1] == "UUID") "blkid -t " $2 " -l -o device" |& getline src;
+    if (o_src[1] == "UUID") "blkid -t " $2 " -l -o device" | getline src;
     else src=o_src[1];
 
     # no password or none is given, ask fo it


### PR DESCRIPTION
Change use of the coprocess pipe operator, a GNU extension, to a
regular pipe when reading data back from blkid(8). Since we aren't
piping data to blkid(8) and then reading it back, we only need a
regular pipe and getline here anyway.

Without this change, using mawk(1) as the default awk on Void
results in failure when parsing /etc/crypttab and dumps us to
a rescue shell on boot.