### PR TITLE
Do not modify /etc/localtime on every boot

### DIFF
--- a/core-services/05-misc.sh
+++ b/core-services/05-misc.sh
@@ -17,5 +17,8 @@ fi
 
 if [ -n "$TIMEZONE" ]; then
     msg "Setting up timezone to '${TIMEZONE}'..."
-    ln -sf "/usr/share/zoneinfo/$TIMEZONE" /etc/localtime
+    [ -L /etc/localtime ] && _tzlink=$(readlink /etc/localtime)
+    if [ "/usr/share/zoneinfo/$TIMEZONE" != "$_tzlink" ]; then
+        ln -sf "/usr/share/zoneinfo/$TIMEZONE" /etc/localtime
+    fi
 fi


### PR DESCRIPTION
Only create or change the symlink when TIMEZONE has a value for the
first time, or when its value doesn't match the current /etc/localtime
symlink. This should prevent an error when /etc/localtime is on a read-only
filesystem, and should prevent a false alarm from an audit tool noticing
a change in its timestamp. It should also help reduce wear on a
filesystem stored on Flash memory.
