### PR TITLE
Adjust options for cp command during install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ install:
 	install -m644 dracut/*.conf ${DESTDIR}/${PREFIX}/lib/dracut/dracut.conf.d
 	ln -sf /run/runit/reboot ${DESTDIR}/etc/runit/
 	ln -sf /run/runit/stopit ${DESTDIR}/etc/runit/
-	cp -aP runsvdir/* ${DESTDIR}/etc/runit/runsvdir/
-	cp -aP services/* ${DESTDIR}/etc/sv/
+	cp -R --no-dereference --preserve=mode,links -v runsvdir/* ${DESTDIR}/etc/runit/runsvdir/
+	cp -R --no-dereference --preserve=mode,links -v services/* ${DESTDIR}/etc/sv/
 
 clean:
 	-rm -f halt pause


### PR DESCRIPTION
cp -a copies the attributes of build user
which may be different from the user on target
in cross compile environment

Fixes errors like

/runit-services/etc/sv/sulogin/run is owned by uid 1000, which is the same as the user running bitbake

Signed-off-by: Khem Raj <raj.khem@gmail.com>