### PR TITLE
Fix "No devices found" error during shutdown

### DIFF
--- a/functions
+++ b/functions
@@ -50,7 +50,7 @@ deactivate_crypt() {
    if [ -x /sbin/dmsetup -o -x /bin/dmsetup ]; then
        msg "Deactivating Crypt Volumes"
        for v in $(dmsetup ls --target crypt --exec "dmsetup info -c --noheadings -o open,name"); do
-           [ ${v%%:*} -eq 0 ] && cryptsetup close ${v##*:}
+           [ ${v%%:*} = "0" ] && cryptsetup close ${v##*:}
        done
        deactivate_vgs "Crypt"
    fi


### PR DESCRIPTION
This fixes an issue introduced by voidlinux/void-runit#75 whereby dmsetup returns "No devices found" on shutdown on systems with no encrypted volumes, which is then interpreted as integral vaules "No", "devices" and "found", resulting in Illegal number errors.