### PR TITLE
Fixed sysctl-file processing order

### DIFF
--- a/core-services/08-sysctl.sh
+++ b/core-services/08-sysctl.sh
@@ -3,10 +3,10 @@
 if [ -x /sbin/sysctl -o -x /bin/sysctl ]; then
     msg "Loading sysctl(8) settings..."
     for i in /run/sysctl.d/*.conf \
-        /etc/sysctl.d/*.conf \
         /usr/local/lib/sysctl.d/*.conf \
         /usr/lib/sysctl.d/*.conf \
-        /etc/sysctl.conf; do
+        /etc/sysctl.conf \
+        /etc/sysctl.d/*.conf; do
 
         if [ -e "$i" ]; then
             printf '* Applying %s ...\n' "$i"


### PR DESCRIPTION
To avoid local administrator settings getting overwritten by vendor
settings.